### PR TITLE
Remove GITHUB_TOKEN from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
 
       - uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}    
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - uses: DfE-Digital/keyvault-yaml-secret@v1
         id:  keyvault-yaml-secret
@@ -52,8 +52,6 @@ jobs:
           keyvault: ${{ env.KEY_VAULT_NAME }}
           secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
           key: CF_USER, CF_PASSWORD
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 ```
 
 ## Contributing


### PR DESCRIPTION
## What
It's not required

## How to review
See here for example: https://github.com/DFE-Digital/get-teacher-training-adviser-service/blob/master/.github/workflows/build.yml#L34-L39